### PR TITLE
Encoding m3u path for Plex

### DIFF
--- a/src/PlaylistDir.py
+++ b/src/PlaylistDir.py
@@ -75,8 +75,7 @@ class Data_Handler:
         try:
             logger.info("Attempting Jellyfin Sync")
             url = f"{self.jellyfin_address}/Library/Refresh?api_key={self.jellyfin_token}"
-            encoded_url = urllib.parse.quote(url, safe='')
-            response = requests.post(encoded_url)
+            response = requests.post(url)
             if response.status_code == 204:
                 logger.info("Jellyfin Library refresh request successful.")
                 return "Success"
@@ -91,9 +90,9 @@ class Data_Handler:
     def add_playlist_to_plex(self, subfolder):
         try:
             m3u_path = os.path.join(self.path_to_playlists, subfolder + ".m3u")
-            url = f"{self.plex_server_ip}/playlists/upload?sectionID={self.plex_library_section_id}&path={m3u_path}&X-Plex-Token={self.x_plex_token}"
-            encoded_url = urllib.parse.quote(url, safe='')
-            response = requests.post(encoded_url)
+            enccoded_m3u_path = urllib.parse.quote(m3u_path, safe='')
+            url = f"{self.plex_server_ip}/playlists/upload?sectionID={self.plex_library_section_id}&path={enccoded_m3u_path}&X-Plex-Token={self.x_plex_token}"
+            response = requests.post(url)
             if response.status_code == 200:
                 logger.info(f"M3U playlist '{self.playlist_file}' imported successfully.")
                 return "Success"

--- a/src/PlaylistDir.py
+++ b/src/PlaylistDir.py
@@ -4,6 +4,8 @@ import datetime
 import threading
 import logging
 import requests
+import urllib.parse
+
 from flask import Flask, render_template, request
 
 
@@ -73,7 +75,8 @@ class Data_Handler:
         try:
             logger.info("Attempting Jellyfin Sync")
             url = f"{self.jellyfin_address}/Library/Refresh?api_key={self.jellyfin_token}"
-            response = requests.post(url)
+            encoded_url = urllib.parse.quote(url, safe='')
+            response = requests.post(encoded_url)
             if response.status_code == 204:
                 logger.info("Jellyfin Library refresh request successful.")
                 return "Success"
@@ -89,7 +92,8 @@ class Data_Handler:
         try:
             m3u_path = os.path.join(self.path_to_playlists, subfolder + ".m3u")
             url = f"{self.plex_server_ip}/playlists/upload?sectionID={self.plex_library_section_id}&path={m3u_path}&X-Plex-Token={self.x_plex_token}"
-            response = requests.post(url)
+            encoded_url = urllib.parse.quote(url, safe='')
+            response = requests.post(encoded_url)
             if response.status_code == 200:
                 logger.info(f"M3U playlist '{self.playlist_file}' imported successfully.")
                 return "Success"


### PR DESCRIPTION
Resolving errors when full path of m3u file has characters that require encoding in the URL to post to Plex.